### PR TITLE
Remove `-` from short url keys

### DIFF
--- a/src/Actions/GenerateAction.php
+++ b/src/Actions/GenerateAction.php
@@ -31,6 +31,6 @@ class GenerateAction
 
     public function urlKey(): string
     {
-        return Str::limit(Str::orderedUuid()->toString(), 13, '');
+        return Str::limit(str_replace('-', '', Str::orderedUuid()->toString()), 12, '');
     }
 }

--- a/tests/Unit/Actions/GenerateActionTest.php
+++ b/tests/Unit/Actions/GenerateActionTest.php
@@ -73,7 +73,7 @@ final class GenerateActionTest extends TestCase
         $urlKey = $this->generateAction->urlKey();
 
         $this->assertIsString($urlKey);
-        $this->assertEquals(13, strlen($urlKey));
+        $this->assertEquals(12, strlen($urlKey));
     }
 
     /** @test */


### PR DESCRIPTION
The `-` are always present in the same position,
it could be removed and this would reduce the short link by one character.

**Before:** `https://yourdomain.com/short/628ac418-865a`
**After:**   `https://yourdomain.com/short/628ac418865a`