### PR TITLE
Support custom names on url keys

### DIFF
--- a/src/Exceptions/UrlKeyAlreadyExistsException.php
+++ b/src/Exceptions/UrlKeyAlreadyExistsException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OrlovTech\ShortLink\Exceptions;
+
+use RuntimeException;
+
+class UrlKeyAlreadyExistsException extends RuntimeException
+{
+}

--- a/tests/Unit/Actions/GenerateActionTest.php
+++ b/tests/Unit/Actions/GenerateActionTest.php
@@ -6,6 +6,7 @@ namespace OrlovTech\ShortLink\Test\Unit\Actions;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use OrlovTech\ShortLink\Actions\GenerateAction;
+use OrlovTech\ShortLink\Exceptions\UrlKeyAlreadyExistsException;
 use OrlovTech\ShortLink\Exceptions\WrongLinkException;
 use OrlovTech\ShortLink\Models\ShortLink;
 use OrlovTech\ShortLink\Test\TestCase;
@@ -83,5 +84,25 @@ final class GenerateActionTest extends TestCase
         $urlKey2 = $this->generateAction->urlKey();
 
         $this->assertNotEquals($urlKey1, $urlKey2);
+    }
+
+    /** @test */
+    public function it_generates_named_url_key(): void
+    {
+        $destinationUrl = 'http://example.com';
+
+        $shortLink = $this->generateAction->generate($destinationUrl, true, 'custom_url_key');
+
+        $this->assertEquals('custom_url_key', $shortLink->url_key);
+    }
+    
+    /** @test */
+    public function it_generates_unique_named_url_key(): void
+    {
+        $destinationUrl = 'http://example.com';
+        $this->expectException(UrlKeyAlreadyExistsException::class);
+
+        $shortLink1 = $this->generateAction->generate($destinationUrl, true, 'custom_url_key');
+        $shortLink2 = $this->generateAction->generate($destinationUrl, true, 'custom_url_key');
     }
 }


### PR DESCRIPTION
By default, the shortened URL that is generated will contain a random key.
Example: if a URL is `https://yourwebapp.com/short/abc1234567890`, the key is `abc1234567890`.

You may wish to define a custom key yourself for that URL that is more meaningful than a randomly generated one. You can do this by using the arg `urlKey`.
Example: 
```php
ShortLink::generate(
    'https://yourlink.com',
    urlKey: 'my_custom_key',
);
// Short URL: https://yourwebapp.com/short/my_custom_key
```
In case `my_custom_key` already exists, `UrlKeyAlreadyExistsException` is thrown
